### PR TITLE
utf-8-mac support

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -19,6 +19,7 @@ WriteMakefile(
         recommends => {
             'I18N::Langinfo' => 0,
 	    'Win32::Console' => 0,
+	    'Encode::UTF8Mac' => 0,
         },
     },
     BUILD_REQUIRES => {

--- a/lib/Encode/Locale.pm
+++ b/lib/Encode/Locale.pm
@@ -61,7 +61,11 @@ sub _init {
     }
 
     if ($^O eq "darwin") {
-	$ENCODING_LOCALE_FS ||= "UTF-8";
+        eval {
+            require Encode::UTF8Mac;
+            $ENCODING_LOCALE_FS ||= "utf-8-mac";
+        };
+    $ENCODING_LOCALE_FS ||= "UTF-8";
     }
 
     # final fallback
@@ -252,13 +256,13 @@ L<Encode> know these encodings as "console_in" and "console_out".
 This table summarizes the mapping of the encodings set up
 by the C<Encode::Locale> module:
 
-  Encode      |         |              |
-  Alias       | Windows | Mac OS X     | POSIX
-  ------------+---------+--------------+------------
-  locale      | ANSI    | nl_langinfo  | nl_langinfo
-  locale_fs   | ANSI    | UTF-8        | nl_langinfo
-  console_in  | OEM     | nl_langinfo  | nl_langinfo
-  console_out | OEM     | nl_langinfo  | nl_langinfo
+  Encode      |         |                    |
+  Alias       | Windows | Mac OS X           | POSIX
+  ------------+---------+--------------------+------------
+  locale      | ANSI    | nl_langinfo        | nl_langinfo
+  locale_fs   | ANSI    | utf-8-mac or UTF-8 | nl_langinfo
+  console_in  | OEM     | nl_langinfo        | nl_langinfo
+  console_out | OEM     | nl_langinfo        | nl_langinfo
 
 =head2 Windows
 
@@ -288,6 +292,9 @@ File names on Mac OS X will at the OS-level be converted to
 NFD form.  A file created by passing a NFC-filename will come
 in NFD from from readdir().  See L<Unicode::Normalize> for details
 of NFD/NFC.
+
+"locale_fs" encoding uses "utf-8-mac" encoding if L<Encode::UTF8Mac>
+is available.
 
 =head2 POSIX (Linux and other Unixes)
 

--- a/t/darwin.t
+++ b/t/darwin.t
@@ -1,0 +1,23 @@
+use strict;
+use Test;
+plan tests => 2;
+
+use Encode;
+use Encode::Locale;
+
+my $skip = not ( $^O eq "darwin" and eval "use Encode::UTF8Mac; 1" );
+
+skip(
+    $skip,
+    sub {
+        Encode::find_encoding('locale_fs')->name() eq 'utf-8-mac';
+    }
+);
+
+skip(
+    $skip,
+    sub {
+        use utf8;
+        Encode::decode('locale_fs', "e\xCC\x81") eq "é";
+    }
+);


### PR DESCRIPTION
This patch is to use "utf-8-mac" encoding on Mac, if Encode::UTF8Mac is avaliable.

http://perl-users.jp/articles/advent-calendar/2010/english/24
https://github.com/gisle/encode-locale/issues#issue/1

regards

-- Tomita
