### PR TITLE
Conditionalize the Win32::Console recommendation

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -18,7 +18,9 @@ WriteMakefile(
         },
         recommends => {
             'I18N::Langinfo' => 0,
-	    'Win32::Console' => 0,
+            ($^O eq 'MSWin32'
+                ? ('Win32::Console' => 0)
+                : ()),
         },
     },
     TEST_REQUIRES => {


### PR DESCRIPTION
Otherwise CPAN clients configured to follow recommended dependencies
will try to install Win32::Console even if they're not running on
Windows.