### PR TITLE
Revert to GetACP() to get the ANSI code page

### DIFF
--- a/lib/Encode/Locale.pm
+++ b/lib/Encode/Locale.pm
@@ -22,28 +22,20 @@ sub DEBUG () { 0 }
 
 sub _init {
     if ($^O eq "MSWin32") {
-	unless ($ENCODING_LOCALE) {
+        unless ($ENCODING_LOCALE) {
 	    # Try to obtain what the Windows ANSI code page is
 	    eval {
-		unless (defined &GetConsoleCP) {
-		    require Win32;
-                    # no point falling back to Win32::GetConsoleCP from this
-                    # as added same time, 0.45
-                    eval { Win32::GetConsoleCP() };
-                    # manually "import" it since Win32->import refuses
-		    *GetConsoleCP = sub { &Win32::GetConsoleCP } unless $@;
-		}
-		unless (defined &GetConsoleCP) {
+		unless (defined &GetACP) {
 		    require Win32::API;
-		    Win32::API->Import('kernel32', 'int GetConsoleCP()');
-		}
-		if (defined &GetConsoleCP) {
-		    my $cp = GetConsoleCP();
+		    Win32::API->Import('kernel32', 'int GetACP()');
+		};
+		if (defined &GetACP) {
+		    my $cp = GetACP();
 		    $ENCODING_LOCALE = "cp$cp" if $cp;
 		}
 	    };
 	}
-
+	
 	unless ($ENCODING_CONSOLE_IN) {
             # only test one since set together
             unless (defined &GetInputCP) {


### PR DESCRIPTION
Reverted to the old behaviour from 1.03 of using GetACP() instead of GetConsoleCP() for getting the system ANSI code page, sinceGetConsoleCP() will only get the console input code page, which has nothing to do with the system ANSI code page.