### PR TITLE
Use GetACP() to get the ANSI code page like before

### DIFF
--- a/lib/Encode/Locale.pm
+++ b/lib/Encode/Locale.pm
@@ -25,20 +25,17 @@ sub _init {
 	unless ($ENCODING_LOCALE) {
 	    # Try to obtain what the Windows ANSI code page is
 	    eval {
-		unless (defined &GetConsoleCP) {
+		unless (defined &GetACP) {
 		    require Win32;
-                    # no point falling back to Win32::GetConsoleCP from this
-                    # as added same time, 0.45
-                    eval { Win32::GetConsoleCP() };
-                    # manually "import" it since Win32->import refuses
-		    *GetConsoleCP = sub { &Win32::GetConsoleCP } unless $@;
+                    eval { Win32::GetACP() };
+		    *GetACP = sub { &Win32::GetACP } unless $@;
 		}
-		unless (defined &GetConsoleCP) {
+		unless (defined &GetACP) {
 		    require Win32::API;
-		    Win32::API->Import('kernel32', 'int GetConsoleCP()');
+		    Win32::API->Import('kernel32', 'int GetACP()');
 		}
-		if (defined &GetConsoleCP) {
-		    my $cp = GetConsoleCP();
+		if (defined &GetACP) {
+		    my $cp = GetACP();
 		    $ENCODING_LOCALE = "cp$cp" if $cp;
 		}
 	    };


### PR DESCRIPTION
Revert to the old behaviour from 1.03 of using GetACP() to the system ANSI code page, since GetConsoleCP() will only get the console input code page, which has nothing to do with the system ANSI code page. Additionally, Win32::GetACP() will be tried before importing with Win32::API.